### PR TITLE
Fix handing id when loading from path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
 * Fixes initialisation of `Protein` objects. [#317](https://github.com/a-r-j/graphein/issues/317) [#318](https://github.com/a-r-j/graphein/pull/318)
 * Fixes incorrect `rad` and `embed` argument logic in `graphein.protein.tensor.angles.dihedrals/sidechain_torsion` [#321](https://github.com/a-r-j/graphein/pull/321)
 * Fixes incorrect start padding in pNeRF output [#321](https://github.com/a-r-j/graphein/pull/321)
+* Fixes setting ID for PyG data objects when loading from a path to a `.pdb` file [#332](https://github.com/a-r-j/graphein/pull/332)
 
 #### Other Changes
 * Adds transform composition to FoldComp Dataset [#312](https://github.com/a-r-j/graphein/pull/312)
@@ -35,6 +36,7 @@
 * Adds transform composition to FoldComp Dataset [#312](https://github.com/a-r-j/graphein/pull/312)
 * Improve FoldComp dataloading performance and include B factors (pLDDT) in output. [#313](https://github.com/a-r-j/graphein/pull/313) [#315](https://github.com/a-r-j/graphein/pull/315)
 * Add new helper functions to PDBManager [#322](https://github.com/a-r-j/graphein/pull/322) (@amorehead)
+* Add non-standard 'CYX' to `RESI_THREE_TO_1`.
 
 ### 1.7.0 - 10 /04/2023
 

--- a/graphein/protein/resi_atoms.py
+++ b/graphein/protein/resi_atoms.py
@@ -652,6 +652,7 @@ RESI_THREE_TO_1: Dict[str, str] = {
     "CSX": "C",
     "CXM": "M",
     "CYS": "C",
+    "CYX": "C",
     "DAL": "A",
     "DAR": "R",
     "DCY": "C",

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -166,7 +166,9 @@ def protein_to_pyg(
     # Get ID
     if path is not None:
         id = (
-            os.path.splitext(path)[0].split("/")[-1] + "_" + "".join(chain_selection)
+            os.path.splitext(path)[0].split("/")[-1]
+            + "_"
+            + "".join(chain_selection)
             if chain_selection != "all"
             else os.path.splitext(path)[0].split("/")[-1]
         )

--- a/graphein/protein/tensor/io.py
+++ b/graphein/protein/tensor/io.py
@@ -166,9 +166,9 @@ def protein_to_pyg(
     # Get ID
     if path is not None:
         id = (
-            path.split("/")[-1] + "_" + "".join(chain_selection)
+            os.path.splitext(path)[0].split("/")[-1] + "_" + "".join(chain_selection)
             if chain_selection != "all"
-            else path
+            else os.path.splitext(path)[0].split("/")[-1]
         )
     elif pdb_code is not None:
         id = (


### PR DESCRIPTION
Previously, the id for the pyg data object would become the entire (possibly length) path to the pdb file OR only the filename + chain ID. However, in the later case, the '.pdb' extension would still show up under the id field.

This commit fixes the above to be consistent and to not contain '.pdb' extension in the pyg data id.

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

#### What does this implement/fix? Explain your changes

#### What testing did you do to verify the changes in this PR?


#### Pull Request Checklist

<!--
Please fill out the following checklist if applicable. For more more information and help, please see the Contributor Documentation avaialable at https://graphein.ai/contributing/contributing.html.
-->

- [ ] Added a note about the modification or contribution to the `./CHANGELOG.md` file (if applicable)
- [ ] Added appropriate unit test functions in the `./graphein/tests/*` directories (if applicable)
- [ ] Modify documentation in the corresponding Jupyter Notebook under `./notebooks/` (if applicable)
- [ ] Ran `python -m py.test tests/` and make sure that all unit tests pass (for small modifications, it might be sufficient to only run the specific test file, e.g., `python -m py.test tests/protein/test_graphs.py`)
- [ ] Checked for style issues by running `black .` and `isort .`


<!--
We value all user contributions, no matter how minor they are.

Thanks for contributing!
-->
